### PR TITLE
[TH-192] Fix input focus issue

### DIFF
--- a/src/components/inputs/number/index.tsx
+++ b/src/components/inputs/number/index.tsx
@@ -11,7 +11,6 @@ import { ButtonPrimarySmall } from '~/components/buttons/primary';
 
 import { formatNumber } from '~/utils';
 
-// TODO: focus 이슈 수정
 type OmitType = 'type' | 'onChange' | 'onBlur';
 interface Props extends Omit<InputHTMLAttributes<HTMLInputElement>, OmitType> {
   balance?: number;
@@ -26,6 +25,8 @@ interface Props extends Omit<InputHTMLAttributes<HTMLInputElement>, OmitType> {
   defaultValue?: number;
 
   focus?: boolean;
+  blured?: boolean;
+  blurAll?: (focused: boolean) => void;
 
   maxButton?: boolean;
   slider?: boolean;
@@ -49,6 +50,8 @@ export const InputNumber = ({
   value,
   handleChange,
   handleTokenClick,
+  blured,
+  blurAll,
 
   name = '',
   control,
@@ -68,9 +71,11 @@ export const InputNumber = ({
 
   useEffect(() => {
     if (!focus) return;
-    if (!handledValue) setFocus(false);
-    else setFocus(handledValue > 0);
-  }, [handledValue, focus]);
+    if (!handledValue || blured) setFocus(false);
+    else {
+      setFocus(handledValue > 0);
+    }
+  }, [handledValue, focus, blured]);
 
   useEffect(() => {
     setValue?.(name ?? '', Number(value || 0), {
@@ -113,11 +118,15 @@ export const InputNumber = ({
                   onValueChange={values => onValueChange(values.floatValue)}
                   customInput={CustomInput}
                   onFocus={() => {
-                    if (focus) setFocus(true);
+                    if (focus) {
+                      setFocus(true);
+                      blurAll?.(false);
+                    }
                   }}
                   onBlur={() => {
                     onBlur();
                     setFocus(false);
+                    blurAll?.(true);
                   }}
                   {...rest}
                 />

--- a/src/pages/pool/components/add-liquidity-input-group.tsx
+++ b/src/pages/pool/components/add-liquidity-input-group.tsx
@@ -146,6 +146,7 @@ export const AddLiquidityInputGroup = ({ pool }: Props) => {
 
       return sum + inputValue * tokenPrice;
     }, 0) ?? 0;
+  const [blured, blurAll] = useState(false);
 
   // TODO : it must be fixed if weight is not 50:50
   const totalValueMaxed =
@@ -197,6 +198,8 @@ export const AddLiquidityInputGroup = ({ pool }: Props) => {
                     setValue={setValue}
                     formState={formState}
                     maxButton={true}
+                    blurAll={blurAll}
+                    blured={blured}
                   />
                 );
               })}


### PR DESCRIPTION
# Description

- 포커스 아웃 시 모든 인풋에서 포커스 사라지게 하기
- 인풋 입력시 갑자기 소숫점들이 생기는 이슈의 경우 formatFloat을 제거하니 없어짐
   - 포맷된 값을 사용하면 자동계산될때 오차가 생길것이기 때문에 지난피알(https://github.com/TeamHeimdallr/moai-web/pull/152)에서 제거했습니다

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
- [x] local test