### PR TITLE
[TH-263] Add skeletons - add liquidity, withdraw, swap

### DIFF
--- a/src/components/skeleton/skeleton-base.tsx
+++ b/src/components/skeleton/skeleton-base.tsx
@@ -3,15 +3,17 @@ import Skeleton, { SkeletonProps } from 'react-loading-skeleton';
 interface SkeletonBaseProps extends SkeletonProps {
   width?: string | number;
   height?: number;
+  borderRadius?: number;
   type?: 'dark' | 'light';
 }
-export const SkeletonBase = ({ width, height, type, ...rest }: SkeletonBaseProps) => {
+export const SkeletonBase = ({ width, height, type, borderRadius, ...rest }: SkeletonBaseProps) => {
   return (
     <Skeleton
       width={width || '100%'}
       height={height}
       baseColor={type === 'dark' ? '#23263A' : '#2B2E44'}
       highlightColor={type === 'dark' ? '#2B2E44' : '#3F4359'}
+      borderRadius={borderRadius || 8}
       duration={0.9}
       {...rest}
     />

--- a/src/hocs/hoc-react-query-provider.tsx
+++ b/src/hocs/hoc-react-query-provider.tsx
@@ -3,7 +3,13 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 interface Props {
   children: React.ReactNode;
 }
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      suspense: true,
+    },
+  },
+});
 const ReactQueryProvider = ({ children }: Props) => {
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
 };

--- a/src/pages/pool/components/add-liquidity-input-group.tsx
+++ b/src/pages/pool/components/add-liquidity-input-group.tsx
@@ -298,9 +298,9 @@ const _AddLiquidityInputGroupSkeleton = () => {
         </IconWrapper>
       </Header>
       <InnerWrapper>
-        <SkeletonBase type="light" height={108} />
-        <SkeletonBase type="light" height={108} />
-        <SkeletonBase type="light" height={100} />
+        <SkeletonBase type="light" height={108} borderRadius={8} />
+        <SkeletonBase type="light" height={108} borderRadius={8} />
+        <SkeletonBase type="light" height={100} borderRadius={8} />
       </InnerWrapper>
       <SkeletonBase type="light" height={48} />
     </SkeletonWrapper>

--- a/src/pages/pool/components/add-liquidity-input-group.tsx
+++ b/src/pages/pool/components/add-liquidity-input-group.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { Suspense, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
@@ -18,6 +18,7 @@ import { Slippage } from '~/components/account';
 import { AlertMessage } from '~/components/alerts';
 import { ButtonPrimaryLarge, ButtonPrimarySmall } from '~/components/buttons';
 import { Checkbox, InputNumber } from '~/components/inputs';
+import { SkeletonBase } from '~/components/skeleton/skeleton-base';
 import { Token } from '~/components/token';
 
 import { usePopup } from '~/hooks/components';
@@ -34,7 +35,16 @@ interface InputFormState {
   input1: number;
   input2: number;
 }
+
 export const AddLiquidityInputGroup = () => {
+  return (
+    <Suspense fallback={<_AddLiquidityInputGroupSkeleton />}>
+      <_AddLiquidityInputGroup />
+    </Suspense>
+  );
+};
+
+const _AddLiquidityInputGroup = () => {
   const ref = useRef<HTMLDivElement>(null);
   const iconRef = useRef<HTMLDivElement>(null);
 
@@ -277,8 +287,33 @@ export const AddLiquidityInputGroup = () => {
   );
 };
 
+const _AddLiquidityInputGroupSkeleton = () => {
+  const { t } = useTranslation();
+  return (
+    <SkeletonWrapper>
+      <Header>
+        <Title>{t('Enter liquidity amount')}</Title>
+        <IconWrapper>
+          <IconSetting fill={'#9296AD'} width={20} height={20} />
+        </IconWrapper>
+      </Header>
+      <InnerWrapper>
+        <SkeletonBase type="light" height={108} />
+        <SkeletonBase type="light" height={108} />
+        <SkeletonBase type="light" height={100} />
+      </InnerWrapper>
+      <SkeletonBase type="light" height={48} />
+    </SkeletonWrapper>
+  );
+};
+
 const Wrapper = tw.div`
   flex flex-col bg-neutral-10 gap-20 px-20 py-16 rounded-12
+  md:(w-452 gap-24 pt-20 px-24 pb-24)
+`;
+
+const SkeletonWrapper = tw.div`
+  w-full flex flex-col bg-neutral-10 gap-20 px-20 py-16 rounded-12
   md:(w-452 gap-24 pt-20 px-24 pb-24)
 `;
 

--- a/src/pages/pool/components/add-liquidity-input-group.tsx
+++ b/src/pages/pool/components/add-liquidity-input-group.tsx
@@ -298,11 +298,11 @@ const _AddLiquidityInputGroupSkeleton = () => {
         </IconWrapper>
       </Header>
       <InnerWrapper>
-        <SkeletonBase type="light" height={108} borderRadius={8} />
-        <SkeletonBase type="light" height={108} borderRadius={8} />
-        <SkeletonBase type="light" height={100} borderRadius={8} />
+        <SkeletonBase type="light" height={108} />
+        <SkeletonBase type="light" height={108} />
+        <SkeletonBase type="light" height={100} />
       </InnerWrapper>
-      <SkeletonBase type="light" height={48} />
+      <SkeletonBase type="light" height={48} borderRadius={12} />
     </SkeletonWrapper>
   );
 };

--- a/src/pages/pool/components/add-liquidity-popup.tsx
+++ b/src/pages/pool/components/add-liquidity-popup.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useMemo, useState } from 'react';
+import { Fragment, Suspense, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import Jazzicon, { jsNumberForAddress } from 'react-jazzicon';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -21,10 +21,13 @@ import { ButtonPrimaryLarge } from '~/components/buttons';
 import { List } from '~/components/lists';
 import { LoadingStep } from '~/components/loadings/step';
 import { Popup } from '~/components/popup';
+import { ListSkeleton } from '~/components/skeleton/list-skeleton';
+import { SkeletonBase } from '~/components/skeleton/skeleton-base';
 import { TokenList } from '~/components/token-list';
 
 import { usePopup } from '~/hooks/components';
 import { useNetwork } from '~/hooks/contexts/use-network';
+import { useMediaQuery } from '~/hooks/utils';
 import {
   DATE_FORMATTER,
   formatNumber,
@@ -48,7 +51,30 @@ interface Props {
 
   refetchBalance?: () => void;
 }
+
 export const AddLiquidityPopup = ({
+  tokensIn,
+  pool,
+  lpTokenPrice,
+  bptOut,
+  priceImpact,
+  refetchBalance,
+}: Props) => {
+  return (
+    <Suspense fallback={<_AddLiquidityPopupSkeleton />}>
+      <_AddLiquidityPopup
+        tokensIn={tokensIn}
+        pool={pool}
+        lpTokenPrice={lpTokenPrice}
+        bptOut={bptOut}
+        priceImpact={priceImpact}
+        refetchBalance={refetchBalance}
+      />
+    </Suspense>
+  );
+};
+
+const _AddLiquidityPopup = ({
   tokensIn,
   pool,
   lpTokenPrice,
@@ -74,6 +100,7 @@ export const AddLiquidityPopup = ({
   const networkAbbr = getNetworkAbbr(network);
   const { network: networkParam } = useParams();
   const { selectedNetwork } = useNetwork();
+  const { isMD } = useMediaQuery();
 
   const [estimatedAddLiquidityFee, setEstimatedAddLiquidityFee] = useState<number | undefined>();
   const [estimatedToken1ApproveFee, setEstimatedToken1ApproveFee] = useState<number | undefined>();
@@ -524,7 +551,7 @@ export const AddLiquidityPopup = ({
         </ButtonWrapper>
       }
     >
-      <Wrapper style={{ gap: isIdle ? 24 : 40 }}>
+      <Wrapper style={{ gap: isIdle ? (isMD ? 24 : 20) : 40 }}>
         {!isIdle && isSuccess && (
           <SuccessWrapper>
             <IconWrapper>
@@ -629,12 +656,28 @@ export const AddLiquidityPopup = ({
   );
 };
 
+const _AddLiquidityPopupSkeleton = () => {
+  const { t } = useTranslation();
+  const { isSMD } = useMediaQuery();
+  return (
+    <Popup id={POPUP_ID.ADD_LP} title={t('Add liquidity preview')}>
+      <Wrapper>
+        <ListSkeleton title={t('You’re providing')} height={191} />
+        <ListSkeleton title={t('You’re expected to receive')} height={118} />
+        <ListSkeleton title={t('Summary')} height={isSMD ? 126 : 183} />
+        <SkeletonBase height={48} />
+      </Wrapper>
+    </Popup>
+  );
+};
+
 const Divider = tw.div`
   w-full h-1 flex-shrink-0 bg-neutral-20
 `;
 
 const Wrapper = tw.div`
-  flex flex-col gap-24 px-24 py-0
+  flex flex-col gap-20 px-20 py-0
+  md:(gap-24 px-24)
 `;
 
 const SuccessTitle = tw.div`

--- a/src/pages/pool/components/withdraw-liquidity-input-group.tsx
+++ b/src/pages/pool/components/withdraw-liquidity-input-group.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useRef, useState } from 'react';
+import { Fragment, Suspense, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
@@ -18,6 +18,7 @@ import { Slippage } from '~/components/account';
 import { AlertMessage } from '~/components/alerts';
 import { ButtonPrimaryLarge } from '~/components/buttons';
 import { InputNumber } from '~/components/inputs';
+import { SkeletonBase } from '~/components/skeleton/skeleton-base';
 import { Tab } from '~/components/tab';
 import { Token } from '~/components/token';
 import { TokenList } from '~/components/token-list';
@@ -33,7 +34,16 @@ import { WithdrawLiquidityPopup } from './withdraw-liquidity-popup';
 interface InputFormState {
   input1: number;
 }
+
 export const WithdrawLiquidityInputGroup = () => {
+  return (
+    <Suspense fallback={<_WithdrawLiquidityInputGroupSkeleton />}>
+      <_WithdrawLiquidityInputGroup />
+    </Suspense>
+  );
+};
+
+const _WithdrawLiquidityInputGroup = () => {
   const ref = useRef<HTMLDivElement>(null);
   const iconRef = useRef<HTMLDivElement>(null);
 
@@ -199,6 +209,37 @@ export const WithdrawLiquidityInputGroup = () => {
           refetchBalance={refetch}
         />
       )}
+    </Wrapper>
+  );
+};
+
+const _WithdrawLiquidityInputGroupSkeleton = () => {
+  const { t } = useTranslation();
+  const tabs = [
+    { key: 'proportional', name: t('Proportional pool tokens') },
+    { key: 'single', name: t('Single token'), disabled: true },
+  ];
+  const { selectedTab } = useWithdrawLiquidityInputGroupTabStore();
+  return (
+    <Wrapper>
+      <Header>
+        <Tab tabs={tabs} selectedTab={selectedTab} />
+        <IconWrapper>
+          <IconSetting fill={'#9296AD'} width={20} height={20} />
+        </IconWrapper>
+      </Header>
+      <InnerWrapper>
+        <ContentWrapper>
+          <SubTitle>{t('You provide')}</SubTitle>
+          <SkeletonBase height={128} />
+        </ContentWrapper>
+        <ContentWrapper>
+          <SubTitle>{t('You receive')}</SubTitle>
+          <SkeletonBase height={145} />
+        </ContentWrapper>
+        <SkeletonBase height={46} />
+        <SkeletonBase height={46} />
+      </InnerWrapper>
     </Wrapper>
   );
 };

--- a/src/pages/pool/components/withdraw-liquidity-input-group.tsx
+++ b/src/pages/pool/components/withdraw-liquidity-input-group.tsx
@@ -231,14 +231,14 @@ const _WithdrawLiquidityInputGroupSkeleton = () => {
       <InnerWrapper>
         <ContentWrapper>
           <SubTitle>{t('You provide')}</SubTitle>
-          <SkeletonBase height={128} borderRadius={8} />
+          <SkeletonBase height={128} />
         </ContentWrapper>
         <ContentWrapper>
           <SubTitle>{t('You receive')}</SubTitle>
-          <SkeletonBase height={145} borderRadius={8} />
+          <SkeletonBase height={145} />
         </ContentWrapper>
-        <SkeletonBase height={46} borderRadius={8} />
         <SkeletonBase height={46} />
+        <SkeletonBase height={46} borderRadius={12} />
       </InnerWrapper>
     </Wrapper>
   );

--- a/src/pages/pool/components/withdraw-liquidity-input-group.tsx
+++ b/src/pages/pool/components/withdraw-liquidity-input-group.tsx
@@ -231,13 +231,13 @@ const _WithdrawLiquidityInputGroupSkeleton = () => {
       <InnerWrapper>
         <ContentWrapper>
           <SubTitle>{t('You provide')}</SubTitle>
-          <SkeletonBase height={128} />
+          <SkeletonBase height={128} borderRadius={8} />
         </ContentWrapper>
         <ContentWrapper>
           <SubTitle>{t('You receive')}</SubTitle>
-          <SkeletonBase height={145} />
+          <SkeletonBase height={145} borderRadius={8} />
         </ContentWrapper>
-        <SkeletonBase height={46} />
+        <SkeletonBase height={46} borderRadius={8} />
         <SkeletonBase height={46} />
       </InnerWrapper>
     </Wrapper>

--- a/src/pages/pool/components/withdraw-liquidity-popup.tsx
+++ b/src/pages/pool/components/withdraw-liquidity-popup.tsx
@@ -605,7 +605,7 @@ const _WithdrawLiquidityPopupSkeleton = () => {
         <ListSkeleton height={114} title={t("You're providing")} />
         <ListSkeleton height={183} title={t("You're expected to receive")} />
         <ListSkeleton height={122} title={t('Summary')} />
-        <SkeletonBase height={48} />
+        <SkeletonBase height={48} borderRadius={12} />
       </Wrapper>
     </Popup>
   );

--- a/src/pages/pool/components/withdraw-liquidity-popup.tsx
+++ b/src/pages/pool/components/withdraw-liquidity-popup.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useMemo, useState } from 'react';
+import { Fragment, Suspense, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import Jazzicon, { jsNumberForAddress } from 'react-jazzicon';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -21,6 +21,8 @@ import { ButtonPrimaryLarge } from '~/components/buttons';
 import { List } from '~/components/lists';
 import { LoadingStep } from '~/components/loadings';
 import { Popup } from '~/components/popup';
+import { ListSkeleton } from '~/components/skeleton/list-skeleton';
+import { SkeletonBase } from '~/components/skeleton/skeleton-base';
 import { TokenList } from '~/components/token-list';
 
 import { usePopup } from '~/hooks/components';
@@ -51,6 +53,32 @@ interface Props {
 }
 
 export const WithdrawLiquidityPopup = ({
+  pool,
+  tokensOut,
+
+  lpTokenPrice,
+  bptIn,
+  priceImpact,
+  withdrawTokenWeight,
+
+  refetchBalance,
+}: Props) => {
+  return (
+    <Suspense fallback={<_WithdrawLiquidityPopupSkeleton />}>
+      <_WithdrawLiquidityPopup
+        pool={pool}
+        tokensOut={tokensOut}
+        lpTokenPrice={lpTokenPrice}
+        bptIn={bptIn}
+        priceImpact={priceImpact}
+        withdrawTokenWeight={withdrawTokenWeight}
+        refetchBalance={refetchBalance}
+      />
+    </Suspense>
+  );
+};
+
+const _WithdrawLiquidityPopup = ({
   pool,
   tokensOut,
 
@@ -564,6 +592,20 @@ export const WithdrawLiquidityPopup = ({
             />
           </>
         )}
+      </Wrapper>
+    </Popup>
+  );
+};
+
+const _WithdrawLiquidityPopupSkeleton = () => {
+  const { t } = useTranslation();
+  return (
+    <Popup id={POPUP_ID.WITHDRAW_LP} title={t('Withdrawal preview')}>
+      <Wrapper>
+        <ListSkeleton height={114} title={t("You're providing")} />
+        <ListSkeleton height={183} title={t("You're expected to receive")} />
+        <ListSkeleton height={122} title={t('Summary')} />
+        <SkeletonBase height={48} />
       </Wrapper>
     </Popup>
   );

--- a/src/pages/pool/pages/detail/detail-skeleton.tsx
+++ b/src/pages/pool/pages/detail/detail-skeleton.tsx
@@ -26,29 +26,30 @@ const _PoolDetailSkeleton = () => {
               width={200}
               height={32}
               type="light"
-              style={{ borderRadius: 40, left: -20 }}
+              borderRadius={40}
+              style={{ left: -20 }}
             />
           </TokenTopWrapper>
           <TokenBottomWrapper>
-            <SkeletonBase width={104} height={32} type="light" style={{ borderRadius: 8 }} />
-            <SkeletonBase width={104} height={32} type="light" style={{ borderRadius: 8 }} />
+            <SkeletonBase width={104} height={32} type="light" />
+            <SkeletonBase width={104} height={32} type="light" />
           </TokenBottomWrapper>
         </TokenWrapper>
         <ContentWrapper>
           <LeftWrapper>
             <Section1>
-              <SkeletonBase width={198} height={108} type="dark" style={{ borderRadius: 12 }} />
-              <SkeletonBase width={198} height={108} type="dark" style={{ borderRadius: 12 }} />
-              <SkeletonBase width={198} height={108} type="dark" style={{ borderRadius: 12 }} />
-              <SkeletonBase width={198} height={108} type="dark" style={{ borderRadius: 12 }} />
+              <SkeletonBase width={198} height={108} type="dark" borderRadius={12} />
+              <SkeletonBase width={198} height={108} type="dark" borderRadius={12} />
+              <SkeletonBase width={198} height={108} type="dark" borderRadius={12} />
+              <SkeletonBase width={198} height={108} type="dark" borderRadius={12} />
             </Section1>
-            <SkeletonBase height={318} type="dark" style={{ borderRadius: 12 }} />
-            <SkeletonBase height={428} type="dark" style={{ borderRadius: 12 }} />
-            <SkeletonBase height={80} type="dark" style={{ borderRadius: 12 }} />
-            <SkeletonBase height={80} type="dark" style={{ borderRadius: 12 }} />
+            <SkeletonBase height={318} type="dark" borderRadius={12} />
+            <SkeletonBase height={428} type="dark" borderRadius={12} />
+            <SkeletonBase height={80} type="dark" borderRadius={12} />
+            <SkeletonBase height={80} type="dark" borderRadius={12} />
           </LeftWrapper>
           <RightWrapper>
-            <SkeletonBase width={400} height={365} type="dark" style={{ borderRadius: 12 }} />
+            <SkeletonBase width={400} height={365} type="dark" borderRadius={12} />
           </RightWrapper>
         </ContentWrapper>
       </InnerWrapper>

--- a/src/pages/swap/components/swap-input-group.tsx
+++ b/src/pages/swap/components/swap-input-group.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { Suspense, useEffect, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
@@ -23,6 +23,7 @@ import { EVM_VAULT_ADDRESS } from '~/constants';
 import { AlertMessage } from '~/components/alerts';
 import { ButtonPrimaryLarge } from '~/components/buttons';
 import { InputNumber } from '~/components/inputs';
+import { SkeletonBase } from '~/components/skeleton/skeleton-base';
 import { Token } from '~/components/token';
 
 import { usePopup } from '~/hooks/components';
@@ -50,7 +51,15 @@ interface InputFormState {
   from: number;
   to: number;
 }
+
 export const SwapInputGroup = () => {
+  return (
+    <Suspense fallback={<_SwapInputGroupSkeleton />}>
+      <_SwapInputGroup />
+    </Suspense>
+  );
+};
+const _SwapInputGroup = () => {
   const { network } = useParams();
   const { selectedNetwork, isEvm, isFpass } = useNetwork();
   const { t } = useTranslation();
@@ -381,6 +390,23 @@ export const SwapInputGroup = () => {
   );
 };
 
+const _SwapInputGroupSkeleton = () => {
+  return (
+    <Wrapper>
+      <InputInnerWrapper>
+        <SkeletonBase height={108} borderRadius={8} />
+        <IconWrapper>
+          <ArrowDownWrapper>
+            <IconArrowDown width={20} height={20} fill={COLOR.PRIMARY[50]} />
+          </ArrowDownWrapper>
+        </IconWrapper>
+        <SkeletonBase height={108} borderRadius={8} />
+      </InputInnerWrapper>
+      <SkeletonBase height={40} style={{ marginTop: 36 }} />
+    </Wrapper>
+  );
+};
+
 const Wrapper = tw.div`
    w-full flex flex-col flex-shrink-0 rounded-12 bg-neutral-10 gap-20 p-20
    md:(w-452 p-24 gap-24)
@@ -395,7 +421,7 @@ const InputInnerWrapper = tw.div`
 `;
 
 const IconWrapper = tw.div`
-  absolute absolute-center-x bottom-100 z-1 clickable select-none
+  absolute absolute-center-x bottom-100 z-2 clickable select-none
 `;
 
 const ArrowDownWrapper = tw.div`

--- a/src/pages/swap/components/swap-input-group.tsx
+++ b/src/pages/swap/components/swap-input-group.tsx
@@ -394,15 +394,15 @@ const _SwapInputGroupSkeleton = () => {
   return (
     <Wrapper>
       <InputInnerWrapper>
-        <SkeletonBase height={108} borderRadius={8} />
+        <SkeletonBase height={108} />
         <IconWrapper>
           <ArrowDownWrapper>
             <IconArrowDown width={20} height={20} fill={COLOR.PRIMARY[50]} />
           </ArrowDownWrapper>
         </IconWrapper>
-        <SkeletonBase height={108} borderRadius={8} />
+        <SkeletonBase height={108} />
       </InputInnerWrapper>
-      <SkeletonBase height={40} style={{ marginTop: 36 }} />
+      <SkeletonBase height={40} borderRadius={12} style={{ marginTop: 36 }} />
     </Wrapper>
   );
 };

--- a/src/states/pages/swap/index.ts
+++ b/src/states/pages/swap/index.ts
@@ -10,11 +10,15 @@ export interface SwapState {
 
   fromInput: number | string;
 
+  selectedDetailInfo: 'TOKEN' | 'USD';
+
   setFromToken: (fromToken?: IToken) => void;
   setToToken: (toToken?: IToken) => void;
 
   setFromInput: (fromInput: number | undefined) => void;
   resetFromValue: () => void;
+
+  selectDetailInfo: (detailInfo: 'TOKEN' | 'USD') => void;
 
   resetAll: () => void;
 }
@@ -29,11 +33,15 @@ export const useSwapStore = create<SwapState>()(
 
       fromInput: '',
 
+      selectedDetailInfo: 'TOKEN',
+
       setFromToken: fromToken => set({ fromToken }),
       setToToken: toToken => set({ toToken }),
 
       setFromInput: fromInput => set({ fromInput }),
       resetFromValue: () => set({ fromInput: '' }),
+
+      selectDetailInfo: selectedDetailInfo => set({ selectedDetailInfo }),
 
       resetAll: () =>
         set({


### PR DESCRIPTION
# Description

- 나머지 skeleton 완료입니다.
  - swap 에서 selected detail info 가 스켈레톤에서 필요해서 swapStore 로 옮겼습니다.

Fixes # (issue)

## Type of change
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [ ] Test A : 직접 호출해 확인

## Screenshots (if appropriate):
Add liquidity, popup

![image](https://github.com/TeamHeimdallr/moai-web/assets/29878878/e752442c-7ca1-477e-bfd1-1e1d930172a8)

![image](https://github.com/TeamHeimdallr/moai-web/assets/29878878/e79e6e23-2d67-483b-a2c4-44a8da83f90c)

Withdraw, popup

![image](https://github.com/TeamHeimdallr/moai-web/assets/29878878/8bf49499-f066-48fc-ac8e-7ef8695c6858)

![image](https://github.com/TeamHeimdallr/moai-web/assets/29878878/e0372930-0093-42aa-a28d-0796a72aa443)

Swap, popup

![image](https://github.com/TeamHeimdallr/moai-web/assets/29878878/2b1e9ec4-ffe7-47dc-897a-a9f302cf9a5c)

![image](https://github.com/TeamHeimdallr/moai-web/assets/29878878/0e5b6c0c-e580-40cf-9001-be8965fc8af4)

